### PR TITLE
Release 1.0.0 + GitHub Actions bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - stable # current stable (newer than minimum when available)
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.2
       - name: Dummy secrets for CI
         run: cp secrets.yaml.example secrets.yaml
       - name: ESPHome compile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.2
       - name: Dummy secrets for CI
         run: cp secrets.yaml.example secrets.yaml
       - name: Firmware version
@@ -46,7 +46,7 @@ jobs:
           mkdir -p "output/${{ steps.version.outputs.version }}"
           mv "${{ steps.esphome-build.outputs.name }}"/* "output/${{ steps.version.outputs.version }}/"
       - name: Upload firmware artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: firmware
           path: output
@@ -56,14 +56,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v6.0.2
       - name: Build
         uses: actions/jekyll-build-pages@v1.0.13
         with:
           source: ./static
           destination: ./output
       - name: Upload
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: site
           path: output
@@ -83,7 +83,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v8.0.1
         with:
           name: firmware
           path: firmware
@@ -93,19 +93,19 @@ jobs:
           mkdir -p output/firmware
           cp -r firmware/${{ needs.build-firmware.outputs.version }}/* output/firmware/
 
-      - uses: actions/download-artifact@v4.1.8
+      - uses: actions/download-artifact@v8.0.1
         with:
           name: site
           path: output
 
-      - uses: actions/upload-pages-artifact@v3.0.1
+      - uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: output
           retention-days: 1
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@v6.0.0
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4.0.5
+        uses: actions/deploy-pages@v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 
 ### Changed
 
+- **GitHub Actions:** bump `actions/checkout` to **v6.0.2**, `actions/upload-artifact` / `actions/download-artifact` to **v7.0.0** / **v8.0.1**, `actions/upload-pages-artifact` to **v4.0.0**, `actions/configure-pages` to **v6.0.0**, and `actions/deploy-pages` to **v5.0.0** (Node.js 20 deprecation on older action pins).
 - **Publish workflow:** deploy to GitHub Pages on **push to `main`** (in addition to releases and `workflow_dispatch`) so the live site stays the Actions-built **`static/`** installer + `firmware/`, instead of going stale or being replaced by a branch-based Jekyll build of **README.md**.
 - **ESPHome versioning:** **2026.3.1** is the **minimum** verified release; **newer** ESPHome (e.g. current **stable**) is explicitly supported. **Publish** uses **`stable`** so GitHub Pages firmware tracks new releases. **CI** compiles against **`2026.3.1`** and **`stable`** (replacing the old **2024.7.3** pin-only setup).
 - **`logger`**: default verbosity set to **`WARN`** (was default / optional `VERBOSE` comment only).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-03-28
+
+First **stable** release. Supersedes prior **0.8 beta** GitHub pre-releases.
+
 ### Added
 
 - **`external_components`** pulling ESPHome `adc` from [PR #7942](https://github.com/esphome/esphome/pull/7942) (`github://pr#7942`) to address ADC deprecation / build issues on newer toolchains.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESPHome: LilyGO T-Display quad sensor dashboard
 
+**Release 1.0.0** — first stable release (see [CHANGELOG.md](CHANGELOG.md)). Create Git tag **`v1.0.0`** on the merge commit when you publish the release on GitHub.
+
 Four Home Assistant temperature entities, battery gauge, and a USB-power indicator on the original **LilyGO T-Display** (ESP32). Prebuilt firmware is published via GitHub Pages and [ESP Web Tools](https://esphome.github.io/esp-web-tools/) for browser-based install.
 
 ## Install prebuilt firmware (web)


### PR DESCRIPTION
## Summary
- Bump official GitHub Actions (`checkout`, `upload-artifact`, `download-artifact`, Pages actions) for the Node.js 20 deprecation path.
- Mark **1.0.0** in CHANGELOG (first stable release; supersedes **0.8 beta** GitHub pre-releases). Empty **\[Unreleased\]** section for future work.
- README: note **Release 1.0.0** and that you should create Git tag `v1.0.0` when publishing the GitHub Release.

## After merge
1. On GitHub: **Releases → Draft a new release**, tag **`v1.0.0`**, target **`main`** (merge commit), title e.g. **1.0.0**, paste CHANGELOG **\[1.0.0\]** section into release notes.
2. Confirm **CI** green on this PR before merge.
3. **Publish** will run on merge to `main`.

## Test plan
- [ ] CI passes on PR
- [ ] After merge, Publish workflow succeeds

Made with [Cursor](https://cursor.com)