### PR TITLE
Release 1.0.1 — CI stable, build-action v7.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,15 @@ concurrency:
 
 jobs:
   ci:
-    name: Build lilygoT-Display-QuadSensor / ESPHome ${{ matrix.esphome-version }}
+    name: Build lilygoT-Display-QuadSensor / ESPHome stable
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        esphome-version:
-          - "2026.3.1" # minimum verified release
-          - stable # current stable (newer than minimum when available)
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6.0.2
       - name: Dummy secrets for CI
         run: cp secrets.yaml.example secrets.yaml
       - name: ESPHome compile
-        uses: esphome/build-action@v7.1.0
+        uses: esphome/build-action@v7.2.0
         with:
           yaml-file: lilygoT-Display-QuadSensor.yaml
-          version: ${{ matrix.esphome-version }}
+          version: stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,11 +32,11 @@ jobs:
           if [ -z "$VERSION" ]; then VERSION="dev-$(date +'%Y%m%d-%H%M')"; fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Build Firmware
-        uses: esphome/build-action@v7.1.0
+        uses: esphome/build-action@v7.2.0
         id: esphome-build
         with:
           yaml-file: lilygoT-Display-QuadSensor.yaml
-          # Minimum verified: 2026.3.1. Use stable so prebuilt firmware tracks current ESPHome releases.
+          # Prebuilt firmware tracks current stable; config last verified on ESPHome 2026.3.1 (see README).
           version: stable
           complete-manifest: true
           release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-03-29
+
+### Changed
+
+- **CI:** single compile job on ESPHome **`stable`** only (removed **2026.3.1** matrix leg).
+- **`esphome/build-action`** → **v7.2.0** in CI and Publish (nested Docker actions updated; addresses Node.js 20 deprecation warnings from older `docker/build-push-action` / `docker/setup-buildx-action` pins in **v7.1.0**).
+- **README / YAML header:** document **stable** as the supported path; **2026.3.1** called out as **last explicitly verified** ESPHome in this repo.
+
 ## [1.0.0] - 2026-03-28
 
 First **stable** release. Supersedes prior **0.8 beta** GitHub pre-releases.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESPHome: LilyGO T-Display quad sensor dashboard
 
-**Release 1.0.0** — first stable release (see [CHANGELOG.md](CHANGELOG.md)). Create Git tag **`v1.0.0`** on the merge commit when you publish the release on GitHub.
+**Release 1.0.1** — patch after 1.0.0 (see [CHANGELOG.md](CHANGELOG.md)). When publishing on GitHub, create tag **`v1.0.1`** (see [Releases](https://github.com/shomanjk/ESPhome-Tdisplay-Quad-Sensor/releases)).
 
 Four Home Assistant temperature entities, battery gauge, and a USB-power indicator on the original **LilyGO T-Display** (ESP32). Prebuilt firmware is published via GitHub Pages and [ESP Web Tools](https://esphome.github.io/esp-web-tools/) for browser-based install.
 
@@ -26,7 +26,7 @@ If you **forked** this repo, use your own Pages URL once Actions publishing work
 ## Requirements
 
 - **Hardware:** Original **LilyGO T-Display** (ESP32). This config has **not** been tested on T-Display *S3* or other variants.
-- **ESPHome:** **2026.3.1** or newer. Older releases are unsupported (BDF fonts and `adc` behavior differ). GitHub **Pages** builds use **current stable** ESPHome; **CI** compiles against **2026.3.1** and **stable**.
+- **ESPHome:** **Pages** and **CI** both compile with **current stable**. Treat **2026.3.1** as the **last explicitly verified** release in this repo; use **stable** locally and expect older ESPHome versions may fail (BDF fonts and `adc` behavior differ).
 - **Home Assistant:** The device uses the **native API** (`api:`). Edit [`lilygoT-Display-QuadSensor.yaml`](lilygoT-Display-QuadSensor.yaml) and set the four `entity_id` values (and `unit_of_measurement` if you do not use °F) to match your entities.
 
 ## What appears on the display

--- a/lilygoT-Display-QuadSensor.yaml
+++ b/lilygoT-Display-QuadSensor.yaml
@@ -1,4 +1,4 @@
-# ESPHome: 2026.3.1 or newer (see README).
+# ESPHome: use current stable; last verified on 2026.3.1 (see README).
 esphome:
   name: refrigerator-quad-temp-display
   friendly_name: Refrigerator Quad Temp Display


### PR DESCRIPTION
## Release 1.0.1
- **CHANGELOG:** new **[1.0.1]** entry; empty **\[Unreleased\]**.
- **README:** current release **1.0.1**, tag **v1.0.1**, link to Releases.
- **CI:** ESPHome **stable** only; **esphome/build-action@v7.2.0** (addresses Node 20 warnings from nested Docker actions in v7.1.0).
- **Publish:** **esphome/build-action@v7.2.0**.
- **README / YAML:** stable as supported path; **2026.3.1** as last verified.

## After merge
Create GitHub Release with tag **v1.0.1** and paste the **[1.0.1]** section from CHANGELOG.

Made with [Cursor](https://cursor.com)